### PR TITLE
Update all developer.box.com references

### DIFF
--- a/_docs/documenting_api_endpoints/docapis_doc_parameters.md
+++ b/_docs/documenting_api_endpoints/docapis_doc_parameters.md
@@ -22,9 +22,9 @@ path1: /docendpoints.html
 
 The following screenshot shows a sample parameters section with the Box API:
 
-{% include course_image.html url="https://developer.box.com/reference#edit-a-collaboration"   filename="boxparameterexample" ext_print="png" ext_web="png" alt="Sample parameters from Box API" caption="Sample parameters from Box API" %}
+{% include course_image.html url="https://developer.box.com/reference/put-comments-id/#request"   filename="boxparameterexample" ext_print="png" ext_web="png" alt="Sample parameters from Box API" caption="Sample parameters from Box API" %}
 
-In this example, the parameters are grouped by type: path parameters, query parameters, and body parameters. The endpoint also sets off the path parameter (`collab_id`) in a recognizable way in the endpoint definition.
+In this example, the parameters are grouped by type: path parameters, query parameters, and body parameters. The endpoint also sets off the path parameter (`comment_id`) in a recognizable way in the endpoint definition.
 
 Many times parameters are simply listed in a table or definition list like this:
 

--- a/_docs/documenting_api_endpoints/docapis_resource_descriptions.md
+++ b/_docs/documenting_api_endpoints/docapis_resource_descriptions.md
@@ -42,9 +42,9 @@ Typically, an API will have a number of endpoints grouped under the same resourc
 * POST `/campaigns/{campaign_id}/actions/test`
 * POST `/campaigns/{campaign_id}/actions/unschedule`
 
-Here's a resource description for the Membership resource in the [Box API](https://developer.box.com/en/reference/resources/group-membership/):
+Here's a resource description for the Membership resource in the [Box API](https://developer.box.com/reference/resources/group-membership/:
 
-<a  class="noCrossRef" href="https://developer.box.com/en/reference/resources/group-membership/" class="noExtIcon"><img src="https://idratherbewritingmedia.com/images/api/boxresources.png" alt="Example from Box" /></a>
+<a  class="noCrossRef" href="https://developer.box.com/reference/resources/group-membership/" class="noExtIcon"><img src="https://idratherbewritingmedia.com/images/api/boxresources.png" alt="Example from Box" /></a>
 
 For the Membership resource (or "object," as they call it), there are 7 different endpoints or methods you can call. The Box API describes the Membership resource and each of the endpoints that lets you access the resource.
 

--- a/_docs/documenting_api_endpoints/docapis_resource_descriptions.md
+++ b/_docs/documenting_api_endpoints/docapis_resource_descriptions.md
@@ -42,7 +42,7 @@ Typically, an API will have a number of endpoints grouped under the same resourc
 * POST `/campaigns/{campaign_id}/actions/test`
 * POST `/campaigns/{campaign_id}/actions/unschedule`
 
-Here's a resource description for the Membership resource in the [Box API](https://developer.box.com/reference/resources/group-membership/:
+Here's a resource description for the Membership resource in the [Box API](https://developer.box.com/reference/resources/group-membership/):
 
 <a  class="noCrossRef" href="https://developer.box.com/reference/resources/group-membership/" class="noExtIcon"><img src="https://idratherbewritingmedia.com/images/api/boxresources.png" alt="Example from Box" /></a>
 

--- a/_docs/documenting_api_endpoints/docapis_resource_endpoints.md
+++ b/_docs/documenting_api_endpoints/docapis_resource_endpoints.md
@@ -70,7 +70,7 @@ See [Request methods](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#
 
 Since there's not much to say about the method itself, it makes sense to group the method with the endpoint. Here's an example from the Box API:
 
-<a href="https://developer.box.com/reference/#add-a-comment-to-an-item" class="noExtIcon"><img src="https://idratherbewritingmedia.com/images/api/methodwithendpoint.png" alt="Box API" /></a>
+<a href="https://developer.box.com/reference/post-comments/" class="noExtIcon"><img src="https://idratherbewritingmedia.com/images/api/methodwithendpoint.png" alt="Box API" /></a>
 
 And here's an example from the Linkedin API:
 

--- a/_docs/publishing_api_documentation/pubapis_api_list.md
+++ b/_docs/publishing_api_documentation/pubapis_api_list.md
@@ -40,7 +40,7 @@ Browse a few of these documentation sites to get a sense of the variety, but als
   <li><a rel="nofollow" href="https://www.docusign.com/developer-center/documentation">Docusign API docs</a></li>
   <li><a rel="nofollow" href="http://www.geonames.org/export/web-services.html">Geonames docs</a></li>
   <li><a rel="nofollow" href="https://developers.google.com/adsense/management/">Adsense API docs</a></li>
-  <li><a rel="nofollow" href="https://developer.box.com/docs">Box API docs</a></li>
+  <li><a rel="nofollow" href="https://developer.box.com/">Box API docs</a></li>
   <li><a rel="nofollow" href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html">Amazon API docs</a></li>
   <li><a rel="nofollow" href="https://developer.linkedin.com/docs/rest-api">Linkedin REST API docs</a></li>
   <li><a rel="nofollow" href="https://instagram.com/developer/">Instagram API docs</a></li>

--- a/_docs/publishing_api_documentation/pubapis_headless_cms.md
+++ b/_docs/publishing_api_documentation/pubapis_headless_cms.md
@@ -72,7 +72,7 @@ Even so, the output is sharp, and the talent behind this site is top-notch. The 
 Here are a few sample API doc sites built with Readme.io:
 
 * [Validic](https://docs.validic.com/docs/getting-started)
-* [Box API](https://developer.box.com/docs)
+* [Box API](https://developer.box.com/)
 * [Coinbase API](https://developers.coinbase.com/api/v2#introduction)
 * [Farmbase Software](https://farmbot-software.readme.io/docs)
 

--- a/slides/documenting_api_endpoints.html
+++ b/slides/documenting_api_endpoints.html
@@ -54,7 +54,7 @@ slide_title: "Documenting API endpoints"
 
              <section>
                 <h3>Box example</h3>
-                <a class="shortened" href="https://developer.box.com/en/reference/resources/group-membership/"><img src="https://idratherbewritingmedia.com/images/api/boxresources.png"/></a>
+                <a class="shortened" href="https://developer.box.com/reference/resources/group-membership/"><img src="https://idratherbewritingmedia.com/images/api/boxresources.png"/></a>
              </section>
 
               <section>
@@ -89,7 +89,7 @@ slide_title: "Documenting API endpoints"
 
                 <section>
                   <h3>Box example</h3>
-                  <a href="https://developer.box.com/en/reference/get-folders-id/"><img src="https://idratherbewritingmedia.com/images/api/boxexample2.png"/></a>
+                  <a href="https://developer.box.com/reference/get-folders-id/"><img src="https://idratherbewritingmedia.com/images/api/boxexample2.png"/></a>
                 </section>
 
                 <section>
@@ -167,7 +167,7 @@ slide_title: "Documenting API endpoints"
 
     <section>
        <h3>Box Example</h3>
-       <a href="https://developer.box.com/en/reference/get-collaborations-id/#request"><img class="shortened" src="https://idratherbewritingmedia.com/images/api/boxparamsscreen2.png" /></a>
+       <a href="https://developer.box.com/reference/get-comments-id/#request"><img class="shortened" src="https://idratherbewritingmedia.com/images/api/boxparamsscreen2.png" /></a>
     </section>
 
     <section>

--- a/slides/openapi_and_swagger.html
+++ b/slides/openapi_and_swagger.html
@@ -204,7 +204,7 @@ paths:
         <section>
           <h2>Readme</h2>
           <figure><a href="https://apitest.readme.io/docs"><img src="https://idratherbewritingmedia.com/images/api/readmedemo.png"/></a>
-<figcaption><small>Demo: <a href="https://developer.box.com/v2.0/reference">Box API</a></small></figcaption></figure>
+<figcaption><small>Demo: <a href="https://developer.mixpanel.com/docs">MixPanel API</a></small></figcaption></figure>
         </section>
 
         <section>


### PR DESCRIPTION
Updated all developer.box.com links to their new canonical URLs. Replaced a few URLs with slightly different endpoints as the existing endpoints no longer showcased the example being referenced. Additionally replaced Box with MixPanel as an example of a README.com user, as we no longer use README.com.

I've also updated all the screenshots as per #18. You can find these here: https://cloud.box.com/s/7arivsctuxvq630o7m3o4rink6hosdfd



